### PR TITLE
Fix handling of expression functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1",
   "description": "Babel plugin that adds the number of assertions found in each test with expect.assertions(n)",
   "main": "dist/index.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "babel src -d dist --ignore *.test.js",
     "contributor": "all-contributors add",
@@ -22,7 +24,14 @@
     "type": "git",
     "url": "git+https://github.com/mattphillips/babel-jest-assertions.git"
   },
-  "keywords": ["babel", "jest", "plugin", "assertions", "expect", "test"],
+  "keywords": [
+    "babel",
+    "jest",
+    "plugin",
+    "assertions",
+    "expect",
+    "test"
+  ],
   "author": "Matt Phillips <matt@mattphillips.io> (mattphillips.io)",
   "license": "MIT",
   "bugs": {
@@ -46,12 +55,20 @@
     "prettier": "^1.6.1"
   },
   "lint-staged": {
-    "*.js": ["yarn prettier", "git add"]
+    "*.js": [
+      "yarn prettier",
+      "git add"
+    ]
   },
   "jest": {
     "testEnvironment": "node",
-    "testPathIgnorePatterns": ["/node_modules/", "/fixtures/"],
-    "coveragePathIgnorePatterns": ["/node_modules/"],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/fixtures/"
+    ],
+    "coveragePathIgnorePatterns": [
+      "/node_modules/"
+    ],
     "coverageThreshold": {
       "global": {
         "branches": 100,
@@ -60,5 +77,8 @@
         "statements": 100
       }
     }
+  },
+  "dependencies": {
+    "babel-generator": "^6.26.0"
   }
 }

--- a/src/__snapshots__/async.test.js.snap
+++ b/src/__snapshots__/async.test.js.snap
@@ -270,3 +270,22 @@ describe('.add', () => {
 });
 "
 `;
+
+exports[`Handles expression functions 1`] = `
+"
+describe('.add', () => {
+  it('returns 1 when given 0 and 1', async () =>
+    expect(add(1, 0)).toEqual(1));
+});
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+describe('.add', () => {
+  it('returns 1 when given 0 and 1', async () => {
+    expect.assertions(1);
+    expect.hasAssertions();
+    return expect(add(1, 0)).toEqual(1);
+  });
+});
+"
+`;

--- a/src/__snapshots__/sync.test.js.snap
+++ b/src/__snapshots__/sync.test.js.snap
@@ -130,7 +130,7 @@ describe('.add', () => {
 
     const a = 1; // expect(a).toEqual(1);
     const b = 2; /* expect(b).toEqual(2); */
-    
+
     expect(add(1, 0)).toEqual(1);
     /*
       expect(add(6, 1).toEqual(7));
@@ -159,6 +159,25 @@ describe('.add', () => {
     /*
       expect(add(6, 1).toEqual(7));
       */
+  });
+});
+"
+`;
+
+exports[`Handles expression functions 1`] = `
+"
+describe('.add', () => {
+  it('returns 1 when given 0 and 1', () =>
+    expect(add(1, 0)).toEqual(1));
+});
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+describe('.add', () => {
+  it('returns 1 when given 0 and 1', () => {
+    expect.assertions(1);
+    expect.hasAssertions();
+    return expect(add(1, 0)).toEqual(1);
   });
 });
 "

--- a/src/async.test.js
+++ b/src/async.test.js
@@ -137,6 +137,15 @@ pluginTester({
         });
       });
       `
+    },
+    'Handles expression functions': {
+      snapshot: true,
+      code: `
+      describe('.add', () => {
+        it('returns 1 when given 0 and 1', async () =>
+          expect(add(1, 0)).toEqual(1));
+      });
+      `
     }
   }
 });

--- a/src/sync.test.js
+++ b/src/sync.test.js
@@ -80,12 +80,21 @@ pluginTester({
 
           const a = 1; // expect(a).toEqual(1);
           const b = 2; /* expect(b).toEqual(2); */
-          
+
           expect(add(1, 0)).toEqual(1);
           /*
             expect(add(6, 1).toEqual(7));
             */
         });
+      });
+      `
+    },
+    'Handles expression functions': {
+      snapshot: true,
+      code: `
+      describe('.add', () => {
+        it('returns 1 when given 0 and 1', () =>
+          expect(add(1, 0)).toEqual(1));
       });
       `
     }


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What

* Converts expression functions into block statements so that we can insert assertions.

```js
describe('test', () => {
  it('works', () => expect(1).toEqual(1));
});
```

becomes:

```js
describe('test', () => {
  it('works', () => {
    expect.assertions(1);
    expect.hasAssertions();

    return expect(1).toEqual(1);
  });
});
```

* This also strips out the test title when scanning for `expect()` calls and considers just the test case body code.

<!-- Why are these changes necessary? Link any related issues -->
### Why

To be able to handle expression functions:

```js
describe('test', () => {
  it('works', () => expect(1).toEqual(1));
});
```
<!-- If necessary add any additional notes on the implementation -->
### Notes

### Housekeeping

- [x] Unit tests
- [x] No additional lint warnings
